### PR TITLE
bump to v1.1.600

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-binary "https://storage.googleapis.com/fiskaly-cdn/clients/com.fiskaly.client-ios-all-v1.1.500.carthage.json" == 1.1.500
+binary "https://storage.googleapis.com/fiskaly-cdn/clients/com.fiskaly.client-ios-all-v1.1.600.carthage.json" == 1.1.600

--- a/FiskalySDK.xcodeproj/project.pbxproj
+++ b/FiskalySDK.xcodeproj/project.pbxproj
@@ -415,7 +415,7 @@
 					"@loader_path/Frameworks",
 				);
 				MACH_O_TYPE = staticlib;
-				MARKETING_VERSION = 1.1.500;
+				MARKETING_VERSION = 1.1.600;
 				PRODUCT_BUNDLE_IDENTIFIER = com.fiskaly.FiskalySDK;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
@@ -450,7 +450,7 @@
 					"@loader_path/Frameworks",
 				);
 				MACH_O_TYPE = staticlib;
-				MARKETING_VERSION = 1.1.500;
+				MARKETING_VERSION = 1.1.600;
 				PRODUCT_BUNDLE_IDENTIFIER = com.fiskaly.FiskalySDK;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;

--- a/FiskalySDK/FiskalyHttpClient.swift
+++ b/FiskalySDK/FiskalyHttpClient.swift
@@ -24,7 +24,7 @@ public class FiskalyHttpClient {
             "api_key": apiKey,
             "api_secret": apiSecret,
             "base_url": baseUrl,
-            "sdk_version": "iOS SDK 1.1.500"
+            "sdk_version": "iOS SDK 1.1.600"
         ]
 
         let request = JsonRpcRequest(method: "create-context", params: contextRequestParams)

--- a/readme.md
+++ b/readme.md
@@ -17,7 +17,7 @@ The fiskaly SDK includes an HTTP client that is needed<sup>[1](#fn1)</sup> for a
 [Carthage](https://github.com/Carthage/Carthage) is a decentralized dependency manager that builds your dependencies and provides you with binary frameworks. To integrate the fiskaly SDK into your Xcode project using Carthage, specify it in your `Cartfile`:
 
 ```ogdl
-github "fiskaly/fiskaly-sdk-swift" "master"
+github "fiskaly/fiskaly-sdk-swift" ~> 1.1.600
 ```
 
 Run the following command to fetch the SDKs source code and build the `FiskalySDK.framework`:


### PR DESCRIPTION
## Motivation

Upgrade of the Client to v1.1.600

## Test Plan

No new tests needed, as there is no new functionality. 
