### PR TITLE
Allow injecting a client instance when initializing a FiskalyHttpClient

### DIFF
--- a/FiskalySDK.xcodeproj/project.pbxproj
+++ b/FiskalySDK.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1FA3FA8E2491671A00348FDE /* FiskalyRequestClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FA3FA8D2491671A00348FDE /* FiskalyRequestClient.swift */; };
 		6A88FA252490C66E00E26BB0 /* com.fiskaly.client-ios-all-v1.1.600.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 6A88FA242490C5D900E26BB0 /* com.fiskaly.client-ios-all-v1.1.600.a */; };
 		6AAD637224606FEF00D2E36A /* FiskalyClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AAD637124606FEF00D2E36A /* FiskalyClientTests.swift */; };
 		6AAD63742460700B00D2E36A /* FiskalyAPITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AAD63732460700B00D2E36A /* FiskalyAPITests.swift */; };
@@ -14,7 +15,6 @@
 		6AD8BBF924488C73000D47BD /* JsonRpcResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AD8BBF824488C73000D47BD /* JsonRpcResponse.swift */; };
 		6AD8BBFB24488C82000D47BD /* JsonRpcError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AD8BBFA24488C82000D47BD /* JsonRpcError.swift */; };
 		6AD8BBFD24488E91000D47BD /* Results.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AD8BBFC24488E91000D47BD /* Results.swift */; };
-		6AEFEB3D24879BA700021EAC /* FiskalyClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AEFEB3C24879BA700021EAC /* FiskalyClient.swift */; };
 		6AEFEB4024879E6400021EAC /* FiskalyClient.h in Headers */ = {isa = PBXBuildFile; fileRef = 6AEFEB3E24879CAD00021EAC /* FiskalyClient.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		6AEFEB482488DCE200021EAC /* Errors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AEFEB472488DCE200021EAC /* Errors.swift */; };
 		D9BFF5BF244629610032D061 /* FiskalySDK.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D9BFF5B5244629610032D061 /* FiskalySDK.framework */; };
@@ -34,6 +34,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		1FA3FA8D2491671A00348FDE /* FiskalyRequestClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FiskalyRequestClient.swift; sourceTree = "<group>"; };
 		6A88FA242490C5D900E26BB0 /* com.fiskaly.client-ios-all-v1.1.600.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = "com.fiskaly.client-ios-all-v1.1.600.a"; sourceTree = SOURCE_ROOT; };
 		6AAD637124606FEF00D2E36A /* FiskalyClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FiskalyClientTests.swift; sourceTree = "<group>"; };
 		6AAD63732460700B00D2E36A /* FiskalyAPITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FiskalyAPITests.swift; sourceTree = "<group>"; };
@@ -41,7 +42,6 @@
 		6AD8BBF824488C73000D47BD /* JsonRpcResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JsonRpcResponse.swift; sourceTree = "<group>"; };
 		6AD8BBFA24488C82000D47BD /* JsonRpcError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JsonRpcError.swift; sourceTree = "<group>"; };
 		6AD8BBFC24488E91000D47BD /* Results.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Results.swift; sourceTree = "<group>"; };
-		6AEFEB3C24879BA700021EAC /* FiskalyClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FiskalyClient.swift; sourceTree = "<group>"; };
 		6AEFEB3E24879CAD00021EAC /* FiskalyClient.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FiskalyClient.h; sourceTree = "<group>"; };
 		6AEFEB3F24879D3400021EAC /* FiskalySDK.modulemap */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.module-map"; path = FiskalySDK.modulemap; sourceTree = "<group>"; };
 		6AEFEB472488DCE200021EAC /* Errors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Errors.swift; sourceTree = "<group>"; };
@@ -100,7 +100,7 @@
 		6AEFEB3B24879B7600021EAC /* FiskalyClient */ = {
 			isa = PBXGroup;
 			children = (
-				6AEFEB3C24879BA700021EAC /* FiskalyClient.swift */,
+				1FA3FA8D2491671A00348FDE /* FiskalyRequestClient.swift */,
 			);
 			path = FiskalyClient;
 			sourceTree = "<group>";
@@ -289,13 +289,13 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				6AEFEB3D24879BA700021EAC /* FiskalyClient.swift in Sources */,
 				6AD8BBFD24488E91000D47BD /* Results.swift in Sources */,
 				6AD8BBF924488C73000D47BD /* JsonRpcResponse.swift in Sources */,
 				D9F90FEF24478702002057D3 /* FiskalyHttpClient.swift in Sources */,
 				6AD8BBFB24488C82000D47BD /* JsonRpcError.swift in Sources */,
 				6AD8BBF024486B18000D47BD /* JsonRpcRequest.swift in Sources */,
 				6AEFEB482488DCE200021EAC /* Errors.swift in Sources */,
+				1FA3FA8E2491671A00348FDE /* FiskalyRequestClient.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/FiskalySDK/Classes/FiskalyClient/FiskalyClient.swift
+++ b/FiskalySDK/Classes/FiskalyClient/FiskalyClient.swift
@@ -1,9 +1,0 @@
-import Foundation
-import FiskalySDK.Client
-
-func fiskalyClientInvoke(_ request: String) -> String {
-    let resultRaw = _fiskaly_client_invoke(request)
-    let result = String(cString: resultRaw!)
-    _fiskaly_client_free(resultRaw)
-    return result
-}

--- a/FiskalySDK/Classes/FiskalyClient/FiskalyRequestClient.swift
+++ b/FiskalySDK/Classes/FiskalyClient/FiskalyRequestClient.swift
@@ -1,0 +1,25 @@
+//
+//  FiskalyRequestClient.swift
+//  FiskalySDK
+//
+//  Created by Marcel Voß on 09.06.20.
+//  Copyright © 2020 fiskaly. All rights reserved.
+//
+
+import Foundation
+import FiskalySDK.Client
+
+public protocol RequestClient {
+    func invoke(request: JsonRpcRequest) -> String
+}
+
+public struct FiskalyRequestClient: RequestClient {
+    public init() { }
+
+    public func invoke(request: JsonRpcRequest) -> String {
+        let resultRaw = _fiskaly_client_invoke(String(describing: request))
+        let result = String(cString: resultRaw!)
+        _fiskaly_client_free(resultRaw)
+        return result
+    }
+}

--- a/FiskalySDK/Classes/FiskalyHttpClient.swift
+++ b/FiskalySDK/Classes/FiskalyHttpClient.swift
@@ -3,12 +3,14 @@ import Foundation
 public class FiskalyHttpClient {
 
     private var context: String
+    private let client: RequestClient
 
     /*
      Initializer
      */
 
-    public init(apiKey: String, apiSecret: String, baseUrl: String) throws {
+    public init(apiKey: String, apiSecret: String, baseUrl: String, client: RequestClient = FiskalyRequestClient()) throws {
+        self.client = client
 
         // version is hardcorded because using versionNumber from header file strips patch number
 
@@ -20,7 +22,7 @@ public class FiskalyHttpClient {
         ]
 
         let request = JsonRpcRequest(method: "create-context", params: contextRequestParams)
-        let jsonData = fiskalyClientInvoke(String(describing: request))
+        let jsonData = client.invoke(request: request)
 
         if let data = jsonData.data(using: .utf8) {
 
@@ -53,7 +55,7 @@ public class FiskalyHttpClient {
     public func version() throws -> ResultVersion {
 
         let request = JsonRpcRequest(method: "version", params: "")
-        let jsonData = fiskalyClientInvoke(String(describing: request))
+        let jsonData = client.invoke(request: request)
         if let data = jsonData.data(using: .utf8) {
 
             let response: JsonRpcResponse<ResultVersion>
@@ -95,7 +97,7 @@ public class FiskalyHttpClient {
         ]
 
         let request = JsonRpcRequest(method: "config", params: configRequestParams)
-        let jsonData = fiskalyClientInvoke(String(describing: request))
+        let jsonData = client.invoke(request: request)
         if let data = jsonData.data(using: .utf8) {
 
             let response: JsonRpcResponse<ResultConfig>
@@ -128,7 +130,7 @@ public class FiskalyHttpClient {
     public func echo(data: String) throws -> String {
 
         let request = JsonRpcRequest(method: "echo", params: data)
-        let jsonData = fiskalyClientInvoke(String(describing: request))
+        let jsonData = client.invoke(request: request)
         if let data = jsonData.data(using: .utf8) {
 
             let response: JsonRpcResponse<String>
@@ -175,7 +177,7 @@ public class FiskalyHttpClient {
         ]
 
         let request = JsonRpcRequest(method: "request", params: requestRequestParams)
-        let jsonData = fiskalyClientInvoke(String(describing: request))
+        let jsonData = client.invoke(request: request)
         if let data = jsonData.data(using: .utf8) {
 
             let response: JsonRpcResponse<ResultRequest>


### PR DESCRIPTION
Hi there,

As we're currently implementing this SDK into the [SumUp](https://sumup.com) merchant app, we want to test its integration without having to rely on Fiskaly's backend being available during e.g. a CI run. Currently, this is incredibly hard and requires some _dirty tricks_ on our side. For simplifying testability in these scenarios, injecting a mock based on a protocol is the easiest way.

This would for example also allow the SDK's tests to move away from using the actual backend and only use mock responses (I didn't convert the tests that are in place, as I wasn't sure that is what you want). Therefore, this PR focusses on adding the infrastructure for making the FiskalyHttpClient testable.

Please let us know what you think, a change like this would massively improve the testability for us.
