### PR TITLE
Upgrade SDK to v1.2.000

### DIFF
--- a/FiskalySDK.xcodeproj/project.pbxproj
+++ b/FiskalySDK.xcodeproj/project.pbxproj
@@ -374,7 +374,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
-				ONLY_ACTIVE_ARCH = YES;
+				ONLY_ACTIVE_ARCH = NO;
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -431,7 +431,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
-				ONLY_ACTIVE_ARCH = YES;
+				ONLY_ACTIVE_ARCH = NO;
 				SDKROOT = iphoneos;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
@@ -453,8 +453,10 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				ENABLE_BITCODE = YES;
 				FRAMEWORK_SEARCH_PATHS = "";
+				GCC_DYNAMIC_NO_PIC = NO;
 				INFOPLIST_FILE = FiskalySDK/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				LD_NO_PIE = NO;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -467,6 +469,10 @@
 				MACH_O_TYPE = mh_dylib;
 				MARKETING_VERSION = 1.2.000;
 				"MODULEMAP_FILE[sdk=*]" = $SRCROOT/FiskalySDK/FiskalySDK.modulemap;
+				OTHER_LDFLAGS = (
+					"-read_only_relocs",
+					suppress,
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.fiskaly.FiskalySDK;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
@@ -490,8 +496,10 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				ENABLE_BITCODE = YES;
 				FRAMEWORK_SEARCH_PATHS = "";
+				GCC_DYNAMIC_NO_PIC = NO;
 				INFOPLIST_FILE = FiskalySDK/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				LD_NO_PIE = NO;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -504,6 +512,10 @@
 				MACH_O_TYPE = mh_dylib;
 				MARKETING_VERSION = 1.2.000;
 				"MODULEMAP_FILE[sdk=*]" = $SRCROOT/FiskalySDK/FiskalySDK.modulemap;
+				OTHER_LDFLAGS = (
+					"-read_only_relocs",
+					suppress,
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.fiskaly.FiskalySDK;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;

--- a/FiskalySDK.xcodeproj/project.pbxproj
+++ b/FiskalySDK.xcodeproj/project.pbxproj
@@ -8,7 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		1FA3FA8E2491671A00348FDE /* FiskalyRequestClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FA3FA8D2491671A00348FDE /* FiskalyRequestClient.swift */; };
-		6A88FA252490C66E00E26BB0 /* com.fiskaly.client-ios-all-v1.1.600.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 6A88FA242490C5D900E26BB0 /* com.fiskaly.client-ios-all-v1.1.600.a */; };
+		6A88FA2B24975EE100E26BB0 /* com.fiskaly.client-ios-all-v1.2.000.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 6A88FA2A24975ED700E26BB0 /* com.fiskaly.client-ios-all-v1.2.000.a */; };
 		6AAD637224606FEF00D2E36A /* FiskalyClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AAD637124606FEF00D2E36A /* FiskalyClientTests.swift */; };
 		6AAD63742460700B00D2E36A /* FiskalyAPITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AAD63732460700B00D2E36A /* FiskalyAPITests.swift */; };
 		6AD8BBF024486B18000D47BD /* JsonRpcRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AD8BBEF24486B18000D47BD /* JsonRpcRequest.swift */; };
@@ -35,7 +35,7 @@
 
 /* Begin PBXFileReference section */
 		1FA3FA8D2491671A00348FDE /* FiskalyRequestClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FiskalyRequestClient.swift; sourceTree = "<group>"; };
-		6A88FA242490C5D900E26BB0 /* com.fiskaly.client-ios-all-v1.1.600.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = "com.fiskaly.client-ios-all-v1.1.600.a"; sourceTree = SOURCE_ROOT; };
+		6A88FA2A24975ED700E26BB0 /* com.fiskaly.client-ios-all-v1.2.000.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = "com.fiskaly.client-ios-all-v1.2.000.a"; sourceTree = SOURCE_ROOT; };
 		6AAD637124606FEF00D2E36A /* FiskalyClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FiskalyClientTests.swift; sourceTree = "<group>"; };
 		6AAD63732460700B00D2E36A /* FiskalyAPITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FiskalyAPITests.swift; sourceTree = "<group>"; };
 		6AD8BBEF24486B18000D47BD /* JsonRpcRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JsonRpcRequest.swift; sourceTree = "<group>"; };
@@ -60,7 +60,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				6A88FA252490C66E00E26BB0 /* com.fiskaly.client-ios-all-v1.1.600.a in Frameworks */,
+				6A88FA2B24975EE100E26BB0 /* com.fiskaly.client-ios-all-v1.2.000.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -151,7 +151,7 @@
 		D9BFF5D624464D1B0032D061 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				6A88FA242490C5D900E26BB0 /* com.fiskaly.client-ios-all-v1.1.600.a */,
+				6A88FA2A24975ED700E26BB0 /* com.fiskaly.client-ios-all-v1.2.000.a */,
 			);
 			path = Frameworks;
 			sourceTree = "<group>";
@@ -280,7 +280,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "CLIENT=com.fiskaly.client-ios-all-v1.1.600.a\n\nif [ ! -f $CLIENT ];\nthen \ncurl -s -o $CLIENT https://storage.googleapis.com/fiskaly-cdn/clients/$CLIENT\nfi\n";
+			shellScript = "CLIENT=com.fiskaly.client-ios-all-v1.2.000.a\n\nif [ ! -f $CLIENT ];\nthen \ncurl -s -o $CLIENT https://storage.googleapis.com/fiskaly-cdn/clients/$CLIENT\nfi\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/FiskalySDK.xcodeproj/project.pbxproj
+++ b/FiskalySDK.xcodeproj/project.pbxproj
@@ -431,6 +431,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
@@ -473,7 +474,6 @@
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				VALID_ARCHS = "arm64 arm64e";
 				VERSIONING_SYSTEM = "apple-generic";
 			};
 			name = Debug;
@@ -510,7 +510,6 @@
 				SUPPORTS_MACCATALYST = NO;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				VALID_ARCHS = "arm64 arm64e";
 				VERSIONING_SYSTEM = "apple-generic";
 			};
 			name = Release;

--- a/FiskalySDK.xcodeproj/project.pbxproj
+++ b/FiskalySDK.xcodeproj/project.pbxproj
@@ -464,7 +464,7 @@
 					"$(PROJECT_DIR)",
 				);
 				MACH_O_TYPE = mh_dylib;
-				MARKETING_VERSION = 1.1.600;
+				MARKETING_VERSION = 1.2.000;
 				"MODULEMAP_FILE[sdk=*]" = $SRCROOT/FiskalySDK/FiskalySDK.modulemap;
 				PRODUCT_BUNDLE_IDENTIFIER = com.fiskaly.FiskalySDK;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
@@ -502,7 +502,7 @@
 					"$(PROJECT_DIR)",
 				);
 				MACH_O_TYPE = mh_dylib;
-				MARKETING_VERSION = 1.1.600;
+				MARKETING_VERSION = 1.2.000;
 				"MODULEMAP_FILE[sdk=*]" = $SRCROOT/FiskalySDK/FiskalySDK.modulemap;
 				PRODUCT_BUNDLE_IDENTIFIER = com.fiskaly.FiskalySDK;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";

--- a/FiskalySDK/Classes/FiskalyHttpClient.swift
+++ b/FiskalySDK/Classes/FiskalyHttpClient.swift
@@ -166,7 +166,6 @@ public class FiskalyHttpClient {
     func performJsonRpcRequest<T: Codable>(request: JsonRpcRequest, _ type: T.Type) throws -> JsonRpcResponse<T> {
 
         let jsonData = try client.invoke(request: request)
-        print(jsonData)
         guard let data = jsonData.data(using: .utf8) else {
             throw FiskalyError.sdkError(message: "Client response not decodeable into JSON.")
         }

--- a/FiskalySDK/Classes/FiskalyHttpClient.swift
+++ b/FiskalySDK/Classes/FiskalyHttpClient.swift
@@ -54,12 +54,34 @@ public class FiskalyHttpClient {
         }
 
     }
+    
+    /*
+     Method: HealthCheck
+     */
+    
+    public func selfTest() throws -> ResultSelfTest {
+        
+        let selfTestRequestParams: [String: Any] = [
+            "context": self.context
+        ]
+        
+        let request = JsonRpcRequest(method: "self-test", params: selfTestRequestParams)
+        let response = try performJsonRpcRequest(request: request, ResultSelfTest.self)
+        if let result = response.result {
+            return result
+        } else if let error = response.error {
+            throw error
+        } else {
+            throw FiskalyError.sdkError(message: "Client error not readable.")
+        }
+        
+    }
 
     /*
      Method: Config
      */
 
-    public func config(debugLevel: Int?, debugFile: String?, clientTimeout: Int?, smaersTimeout: Int?) throws -> Config {
+    public func config(debugLevel: Int?, debugFile: String?, clientTimeout: Int?, smaersTimeout: Int?, httpProxy: String?) throws -> Config {
 
         let configRequestParams: [String: Any] = [
             "context": self.context,
@@ -67,7 +89,8 @@ public class FiskalyHttpClient {
                 "debug_level": debugLevel ?? -1,
                 "debug_file": debugFile ?? "",
                 "client_timeout": clientTimeout ?? 0,
-                "smaers_timeout": smaersTimeout ?? 0
+                "smaers_timeout": smaersTimeout ?? 0,
+                "http_proxy": httpProxy ?? ""
             ]
         ]
 
@@ -143,6 +166,7 @@ public class FiskalyHttpClient {
     func performJsonRpcRequest<T: Codable>(request: JsonRpcRequest, _ type: T.Type) throws -> JsonRpcResponse<T> {
 
         let jsonData = try client.invoke(request: request)
+        print(jsonData)
         guard let data = jsonData.data(using: .utf8) else {
             throw FiskalyError.sdkError(message: "Client response not decodeable into JSON.")
         }

--- a/FiskalySDK/Classes/FiskalyHttpClient.swift
+++ b/FiskalySDK/Classes/FiskalyHttpClient.swift
@@ -22,7 +22,7 @@ public class FiskalyHttpClient {
             "api_key": apiKey,
             "api_secret": apiSecret,
             "base_url": baseUrl,
-            "sdk_version": "iOS SDK 1.1.600"
+            "sdk_version": "iOS SDK 1.2.000"
         ]
 
         let request = JsonRpcRequest(method: "create-context", params: contextRequestParams)
@@ -54,17 +54,17 @@ public class FiskalyHttpClient {
         }
 
     }
-    
+
     /*
      Method: HealthCheck
      */
-    
+
     public func selfTest() throws -> ResultSelfTest {
-        
+
         let selfTestRequestParams: [String: Any] = [
             "context": self.context
         ]
-        
+
         let request = JsonRpcRequest(method: "self-test", params: selfTestRequestParams)
         let response = try performJsonRpcRequest(request: request, ResultSelfTest.self)
         if let result = response.result {
@@ -74,7 +74,7 @@ public class FiskalyHttpClient {
         } else {
             throw FiskalyError.sdkError(message: "Client error not readable.")
         }
-        
+
     }
 
     /*

--- a/FiskalySDK/Classes/Results.swift
+++ b/FiskalySDK/Classes/Results.swift
@@ -28,6 +28,16 @@ public class SMAERSVersion: Codable {
 }
 
 /*
+ HealthCheck
+ */
+
+public class ResultSelfTest: Codable {
+    public var proxy: String
+    public var backend: String
+    public var smaers: String
+}
+
+/*
  Config
  */
 
@@ -41,6 +51,7 @@ public class Config: Codable {
     public var debugFile: String
     public var clientTimeout: Int
     public var smaersTimeout: Int
+    public var httpProxy: String
 }
 
 /*

--- a/FiskalySDKTests/FiskalyClientTests.swift
+++ b/FiskalySDKTests/FiskalyClientTests.swift
@@ -15,7 +15,7 @@ class FiskalyClientTests: XCTestCase {
         XCTAssertNotEqual(response.client.commitHash, "")
         XCTAssertNotEqual(response.smaers.version, "")
     }
-    
+
     func testSelfTest() throws {
         let client = try FiskalyHttpClient(
             apiKey: "API_KEY",

--- a/FiskalySDKTests/FiskalyClientTests.swift
+++ b/FiskalySDKTests/FiskalyClientTests.swift
@@ -15,6 +15,17 @@ class FiskalyClientTests: XCTestCase {
         XCTAssertNotEqual(response.client.commitHash, "")
         XCTAssertNotEqual(response.smaers.version, "")
     }
+    
+    func testSelfTest() throws {
+        let client = try FiskalyHttpClient(
+            apiKey: "API_KEY",
+            apiSecret: "API_SECRET",
+            baseUrl: "https://kassensichv.io/api/v1/"
+        )
+        let response = try client.selfTest()
+        XCTAssertNotEqual(response.backend, "")
+        XCTAssertNotEqual(response.smaers, "")
+    }
 
     func testConfig() throws {
         let client = try FiskalyHttpClient(
@@ -26,11 +37,13 @@ class FiskalyClientTests: XCTestCase {
             debugLevel: -1,
             debugFile: "tmp/tmp.log",
             clientTimeout: 1500,
-            smaersTimeout: 1500)
+            smaersTimeout: 1500,
+            httpProxy: "")
         XCTAssertEqual(response.debugLevel, -1)
         XCTAssertEqual(response.debugFile, "tmp/tmp.log")
         XCTAssertEqual(response.clientTimeout, 1500)
         XCTAssertEqual(response.smaersTimeout, 1500)
+        XCTAssertEqual(response.httpProxy, "")
     }
 
     func testEcho() throws {

--- a/readme.md
+++ b/readme.md
@@ -17,7 +17,7 @@ The fiskaly SDK includes an HTTP client that is needed<sup>[1](#fn1)</sup> for a
 [Carthage](https://github.com/Carthage/Carthage) is a decentralized dependency manager that builds your dependencies and provides you with binary frameworks. To integrate the fiskaly SDK into your Xcode project using Carthage, specify it in your `Cartfile`:
 
 ```ogdl
-github "fiskaly/fiskaly-sdk-swift" ~> 1.1.600
+github "fiskaly/fiskaly-sdk-swift" ~> 1.2.000
 ```
 
 Run the following command to fetch the SDKs source code and build the `FiskalySDK.framework`:
@@ -71,6 +71,17 @@ do {
 }
 ```
 
+### Running the Self-Test
+
+```swift
+do {
+    let response = try client.selfTest()
+    print(response)
+} catch {
+    print("Error while selftesting: \(error)")
+}
+```
+
 ### Client Configuration
 
 The SDK is built on the [fiskaly Client](https://developer.fiskaly.com/en/docs/client-documentation) which can be [configured](https://developer.fiskaly.com/en/docs/client-documentation#configuration) through the SDK.
@@ -82,7 +93,8 @@ do {
                     debugLevel: -1,
                     debugFile: "tmp/tmp.log",
                     clientTimeout: 1500,
-                    smaersTimeout: 1500)
+                    smaersTimeout: 1500, 
+                    httpProxy: "")
     print(response)
 } catch {
     print("Error while setting config: \(error)")


### PR DESCRIPTION
## Version Bump to 1.2.000

- Added back armv7 support mentioned in last PR
- Changed dynamic framework to static
- Made methods truly synchronous 
- Improved Error Handling 
- Removed all force unwrapping
- Narrowed down Responses for better usability 
- Added the option to inject a client instance to improve test-ability (thanks to @marcelvoss) 

### Note 
Build doesn't run because new client build isn't published yet

### Coming up in the next release

- Cocoapods 
- Further improvements to Error Handling 
- Better Test Catalog