### PR TITLE
M1 fix

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,10 +14,10 @@ jobs:
       - name: Checkout 
         uses: actions/checkout@v1
 
-      - name: Force Xcode 11.3
+      - name: Force Xcode 12
         run: |
           sudo xcode-select \
-                  -switch /Applications/XCode_11.3.app
+                  -switch /Applications/XCode_12.app
 
       - name: Xcode version
         run: /usr/bin/xcodebuild -version

--- a/.github/workflows/xcodebuild.yml
+++ b/.github/workflows/xcodebuild.yml
@@ -15,10 +15,10 @@ jobs:
       - name: Checkout 
         uses: actions/checkout@v1
 
-      - name: Force Xcode 11.3
+      - name: Force Xcode 12
         run: |
           sudo xcode-select \
-                  -switch /Applications/XCode_11.3.app
+                  -switch /Applications/XCode_12.app
 
       - name: Xcode version
         run: /usr/bin/xcodebuild -version

--- a/FiskalyClient/.gitignore
+++ b/FiskalyClient/.gitignore
@@ -1,0 +1,7 @@
+.DS_Store
+/.build
+/Packages
+/*.xcodeproj
+xcuserdata/
+DerivedData/
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata

--- a/FiskalyClient/Package.swift
+++ b/FiskalyClient/Package.swift
@@ -7,7 +7,7 @@ let client = "com.fiskaly.client-ios-all-v2.0.0"
 let package = Package(
     name: client,
     platforms: [
-        .iOS(.v13)
+        .iOS(.v12)
     ],
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.

--- a/FiskalyClient/Package.swift
+++ b/FiskalyClient/Package.swift
@@ -1,0 +1,29 @@
+// swift-tools-version:5.3
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let client = "com.fiskaly.client-ios-all-v2.0.0"
+let package = Package(
+    name: client,
+    platforms: [
+        .iOS(.v13)
+    ],
+    products: [
+        // Products define the executables and libraries a package produces, and make them visible to other packages.
+        .library(
+            name: client,
+            targets: [client]),
+    ],
+    dependencies: [
+        // Dependencies declare other packages that this package depends on.
+        // .package(url: /* package url */, from: "1.0.0"),
+    ],
+    targets: [
+        .binaryTarget(
+                 name: client,
+                 url: "https://storage.googleapis.com/fiskaly-cdn/clients/\(client).zip",
+                 checksum: "6daaf6c72987f0437f3f16a1430746edb4ca44e9d886920a5726cfa08b27dbaf"
+             )
+    ]
+)

--- a/FiskalyClient/README.md
+++ b/FiskalyClient/README.md
@@ -1,3 +1,3 @@
 # FiskalyClient
 
-A description of this package.
+An HTTP client to simplify access to Fiskaly APIs.

--- a/FiskalyClient/README.md
+++ b/FiskalyClient/README.md
@@ -1,0 +1,3 @@
+# FiskalyClient
+
+A description of this package.

--- a/FiskalyClient/Sources/FiskalyClient/FiskalyClient.swift
+++ b/FiskalyClient/Sources/FiskalyClient/FiskalyClient.swift
@@ -1,0 +1,3 @@
+struct FiskalyClient {
+    var text = "Hello, World!"
+}

--- a/FiskalyClient/Tests/FiskalyClientTests/FiskalyClientTests.swift
+++ b/FiskalyClient/Tests/FiskalyClientTests/FiskalyClientTests.swift
@@ -1,0 +1,11 @@
+    import XCTest
+    @testable import FiskalyClient
+
+    final class FiskalyClientTests: XCTestCase {
+        func testExample() {
+            // This is an example of a functional test case.
+            // Use XCTAssert and related functions to verify your tests produce the correct
+            // results.
+            XCTAssertEqual(FiskalyClient().text, "Hello, World!")
+        }
+    }

--- a/FiskalySDK.xcodeproj/project.pbxproj
+++ b/FiskalySDK.xcodeproj/project.pbxproj
@@ -8,7 +8,6 @@
 
 /* Begin PBXBuildFile section */
 		1FA3FA8E2491671A00348FDE /* FiskalyRequestClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FA3FA8D2491671A00348FDE /* FiskalyRequestClient.swift */; };
-		6A5A359024E558BC00F40778 /* com.fiskaly.client-ios-all-v1.2.100.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 6A5A358F24E558B100F40778 /* com.fiskaly.client-ios-all-v1.2.100.a */; };
 		6AAD637224606FEF00D2E36A /* FiskalyClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AAD637124606FEF00D2E36A /* FiskalyClientTests.swift */; };
 		6AAD63742460700B00D2E36A /* FiskalyAPITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AAD63732460700B00D2E36A /* FiskalyAPITests.swift */; };
 		6AD8BBF024486B18000D47BD /* JsonRpcRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AD8BBEF24486B18000D47BD /* JsonRpcRequest.swift */; };
@@ -21,6 +20,8 @@
 		D9BFF5C4244629610032D061 /* FiskalySDKTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9BFF5C3244629610032D061 /* FiskalySDKTests.swift */; };
 		D9BFF5C6244629610032D061 /* FiskalySDK.h in Headers */ = {isa = PBXBuildFile; fileRef = D9BFF5B8244629610032D061 /* FiskalySDK.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D9F90FEF24478702002057D3 /* FiskalyHttpClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9F90FEE24478702002057D3 /* FiskalyHttpClient.swift */; };
+		E9807174266FAB5A00A099C2 /* com.fiskaly.client-ios-all-v1.2.200.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E980716E266A1C8400A099C2 /* com.fiskaly.client-ios-all-v1.2.200.a */; };
+		E9807175266FAB5B00A099C2 /* com.fiskaly.client-ios-all-v1.2.200.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E980716E266A1C8400A099C2 /* com.fiskaly.client-ios-all-v1.2.200.a */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -35,7 +36,6 @@
 
 /* Begin PBXFileReference section */
 		1FA3FA8D2491671A00348FDE /* FiskalyRequestClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FiskalyRequestClient.swift; sourceTree = "<group>"; };
-		6A5A358F24E558B100F40778 /* com.fiskaly.client-ios-all-v1.2.100.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = "com.fiskaly.client-ios-all-v1.2.100.a"; sourceTree = SOURCE_ROOT; };
 		6AAD637124606FEF00D2E36A /* FiskalyClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FiskalyClientTests.swift; sourceTree = "<group>"; };
 		6AAD63732460700B00D2E36A /* FiskalyAPITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FiskalyAPITests.swift; sourceTree = "<group>"; };
 		6AD8BBEF24486B18000D47BD /* JsonRpcRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JsonRpcRequest.swift; sourceTree = "<group>"; };
@@ -53,6 +53,8 @@
 		D9BFF5C5244629610032D061 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		D9F90FEE24478702002057D3 /* FiskalyHttpClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FiskalyHttpClient.swift; sourceTree = "<group>"; };
 		D9F90FF424478A8C002057D3 /* readme.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = readme.md; sourceTree = "<group>"; };
+		E980716E266A1C8400A099C2 /* com.fiskaly.client-ios-all-v1.2.200.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = "com.fiskaly.client-ios-all-v1.2.200.a"; sourceTree = "<group>"; };
+		E9807171266FA5FE00A099C2 /* com.fiskaly.client-darwin-arm64-v1.2.100.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; path = "com.fiskaly.client-darwin-arm64-v1.2.100.dylib"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -60,7 +62,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				6A5A359024E558BC00F40778 /* com.fiskaly.client-ios-all-v1.2.100.a in Frameworks */,
+				E9807174266FAB5A00A099C2 /* com.fiskaly.client-ios-all-v1.2.200.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -69,6 +71,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				D9BFF5BF244629610032D061 /* FiskalySDK.framework in Frameworks */,
+				E9807175266FAB5B00A099C2 /* com.fiskaly.client-ios-all-v1.2.200.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -151,7 +154,8 @@
 		D9BFF5D624464D1B0032D061 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				6A5A358F24E558B100F40778 /* com.fiskaly.client-ios-all-v1.2.100.a */,
+				E9807171266FA5FE00A099C2 /* com.fiskaly.client-darwin-arm64-v1.2.100.dylib */,
+				E980716E266A1C8400A099C2 /* com.fiskaly.client-ios-all-v1.2.200.a */,
 			);
 			path = Frameworks;
 			sourceTree = "<group>";
@@ -215,7 +219,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 1140;
-				LastUpgradeCheck = 1150;
+				LastUpgradeCheck = 1250;
 				ORGANIZATIONNAME = fiskaly;
 				TargetAttributes = {
 					D9BFF5B4244629610032D061 = {
@@ -324,6 +328,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = (
+					arm64,
+					x86_64,
+				);
 				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
@@ -347,6 +355,7 @@
 				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
 				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
@@ -373,18 +382,16 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
-				ONLY_ACTIVE_ARCH = NO;
-				OTHER_LDFLAGS = (
-					"-read_only_relocs",
-					suppress,
-				);
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_LDFLAGS = "";
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				VALID_ARCHS = "$(ARCHS_STANDARD)";
+				VALID_ARCHS = arm64;
+				"VALID_ARCHS[sdk=iphonesimulator*]" = "arm64 x86_64";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -394,6 +401,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = (
+					arm64,
+					x86_64,
+				);
 				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
@@ -417,6 +428,7 @@
 				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
 				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
@@ -437,19 +449,17 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
-				ONLY_ACTIVE_ARCH = NO;
-				OTHER_LDFLAGS = (
-					"-read_only_relocs",
-					suppress,
-				);
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_LDFLAGS = "";
 				SDKROOT = iphoneos;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
 				VALIDATE_PRODUCT = YES;
-				VALID_ARCHS = "$(ARCHS_STANDARD)";
+				VALID_ARCHS = arm64;
+				"VALID_ARCHS[sdk=iphonesimulator*]" = "arm64 x86_64";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -470,7 +480,7 @@
 				FRAMEWORK_SEARCH_PATHS = "";
 				GCC_DYNAMIC_NO_PIC = NO;
 				INFOPLIST_FILE = FiskalySDK/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_NO_PIE = NO;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -480,15 +490,12 @@
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)",
+					"$(PROJECT_DIR)/Frameworks",
 				);
 				MACH_O_TYPE = mh_dylib;
 				MARKETING_VERSION = 1.2.100;
 				"MODULEMAP_FILE[sdk=*]" = $SRCROOT/FiskalySDK/FiskalySDK.modulemap;
 				ONLY_ACTIVE_ARCH = NO;
-				OTHER_LDFLAGS = (
-					"-read_only_relocs",
-					suppress,
-				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.fiskaly.FiskalySDK;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
@@ -496,7 +503,9 @@
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				VALID_ARCHS = "$(ARCHS_STANDARD)";
+				VALIDATE_WORKSPACE = YES;
+				VALID_ARCHS = arm64;
+				"VALID_ARCHS[sdk=iphonesimulator*]" = "arm64 x86_64";
 				VERSIONING_SYSTEM = "apple-generic";
 			};
 			name = Debug;
@@ -516,7 +525,7 @@
 				FRAMEWORK_SEARCH_PATHS = "";
 				GCC_DYNAMIC_NO_PIC = NO;
 				INFOPLIST_FILE = FiskalySDK/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_NO_PIE = NO;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -526,22 +535,21 @@
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)",
+					"$(PROJECT_DIR)/Frameworks",
 				);
 				MACH_O_TYPE = mh_dylib;
 				MARKETING_VERSION = 1.2.100;
 				"MODULEMAP_FILE[sdk=*]" = $SRCROOT/FiskalySDK/FiskalySDK.modulemap;
 				ONLY_ACTIVE_ARCH = NO;
-				OTHER_LDFLAGS = (
-					"-read_only_relocs",
-					suppress,
-				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.fiskaly.FiskalySDK;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
 				SUPPORTS_MACCATALYST = NO;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				VALID_ARCHS = "$(ARCHS_STANDARD)";
+				VALIDATE_WORKSPACE = YES;
+				VALID_ARCHS = arm64;
+				"VALID_ARCHS[sdk=iphonesimulator*]" = "arm64 x86_64";
 				VERSIONING_SYSTEM = "apple-generic";
 			};
 			name = Release;
@@ -550,21 +558,29 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)",
 				);
 				INFOPLIST_FILE = FiskalySDKTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)",
+					"$(PROJECT_DIR)/Frameworks",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.fiskaly.FiskalySDKTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
+				VALID_ARCHS = arm64;
+				"VALID_ARCHS[sdk=iphonesimulator*]" = "arm64 x86_64";
 			};
 			name = Debug;
 		};
@@ -572,21 +588,29 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)",
 				);
 				INFOPLIST_FILE = FiskalySDKTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)",
+					"$(PROJECT_DIR)/Frameworks",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.fiskaly.FiskalySDKTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
+				VALID_ARCHS = arm64;
+				"VALID_ARCHS[sdk=iphonesimulator*]" = "arm64 x86_64";
 			};
 			name = Release;
 		};

--- a/FiskalySDK.xcodeproj/project.pbxproj
+++ b/FiskalySDK.xcodeproj/project.pbxproj
@@ -6,6 +6,20 @@
 	objectVersion = 52;
 	objects = {
 
+/* Begin PBXAggregateTarget section */
+		E9A6830E26833E2F000605EF /* FiskalySDK-framework */ = {
+			isa = PBXAggregateTarget;
+			buildConfigurationList = E9A6830F26833E2F000605EF /* Build configuration list for PBXAggregateTarget "FiskalySDK-framework" */;
+			buildPhases = (
+				E9A6831226833E86000605EF /* Make XCFramework */,
+			);
+			dependencies = (
+			);
+			name = "FiskalySDK-framework";
+			productName = "FiskalySDK-framework";
+		};
+/* End PBXAggregateTarget section */
+
 /* Begin PBXBuildFile section */
 		1FA3FA8E2491671A00348FDE /* FiskalyRequestClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FA3FA8D2491671A00348FDE /* FiskalyRequestClient.swift */; };
 		6AAD637224606FEF00D2E36A /* FiskalyClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AAD637124606FEF00D2E36A /* FiskalyClientTests.swift */; };
@@ -53,6 +67,7 @@
 		D9BFF5C5244629610032D061 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		D9F90FEE24478702002057D3 /* FiskalyHttpClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FiskalyHttpClient.swift; sourceTree = "<group>"; };
 		D9F90FF424478A8C002057D3 /* readme.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = readme.md; sourceTree = "<group>"; };
+		E951483C268233DC0026A559 /* build_xcframework.sh */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.sh; path = build_xcframework.sh; sourceTree = "<group>"; };
 		E99EA84F2678968A00B04017 /* com.fiskaly.client-ios-all-v1.2.200.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; path = "com.fiskaly.client-ios-all-v1.2.200.xcframework"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -111,6 +126,7 @@
 			isa = PBXGroup;
 			children = (
 				D9F90FF424478A8C002057D3 /* readme.md */,
+				E951483C268233DC0026A559 /* build_xcframework.sh */,
 				D9BFF5B7244629610032D061 /* FiskalySDK */,
 				D9BFF5C2244629610032D061 /* FiskalySDKTests */,
 				D9BFF5B6244629610032D061 /* Products */,
@@ -227,6 +243,9 @@
 					D9BFF5BD244629610032D061 = {
 						CreatedOnToolsVersion = 11.4;
 					};
+					E9A6830E26833E2F000605EF = {
+						CreatedOnToolsVersion = 12.5;
+					};
 				};
 			};
 			buildConfigurationList = D9BFF5AF244629610032D061 /* Build configuration list for PBXProject "FiskalySDK" */;
@@ -244,6 +263,7 @@
 			targets = (
 				D9BFF5B4244629610032D061 /* FiskalySDK */,
 				D9BFF5BD244629610032D061 /* FiskalySDKTests */,
+				E9A6830E26833E2F000605EF /* FiskalySDK-framework */,
 			);
 		};
 /* End PBXProject section */
@@ -283,6 +303,24 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "CLIENT=com.fiskaly.client-ios-all-v1.2.100.a\n\nif [ ! -f $CLIENT ];\nthen \ncurl -s -o $CLIENT https://storage.googleapis.com/fiskaly-cdn/clients/$CLIENT\nfi\n";
+		};
+		E9A6831226833E86000605EF /* Make XCFramework */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Make XCFramework";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "$SRCROOT/build_xcframework.sh\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -466,7 +504,6 @@
 				FRAMEWORK_SEARCH_PATHS = "";
 				GCC_DYNAMIC_NO_PIC = NO;
 				INFOPLIST_FILE = FiskalySDK/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_NO_PIE = NO;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -509,7 +546,6 @@
 				FRAMEWORK_SEARCH_PATHS = "";
 				GCC_DYNAMIC_NO_PIC = NO;
 				INFOPLIST_FILE = FiskalySDK/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_NO_PIE = NO;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -592,6 +628,24 @@
 			};
 			name = Release;
 		};
+		E9A6831026833E2F000605EF /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = BM8FD7M6C6;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Debug;
+		};
+		E9A6831126833E2F000605EF /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = BM8FD7M6C6;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -618,6 +672,15 @@
 			buildConfigurations = (
 				D9BFF5CD244629610032D061 /* Debug */,
 				D9BFF5CE244629610032D061 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		E9A6830F26833E2F000605EF /* Build configuration list for PBXAggregateTarget "FiskalySDK-framework" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				E9A6831026833E2F000605EF /* Debug */,
+				E9A6831126833E2F000605EF /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/FiskalySDK.xcodeproj/project.pbxproj
+++ b/FiskalySDK.xcodeproj/project.pbxproj
@@ -34,7 +34,7 @@
 		D9BFF5C4244629610032D061 /* FiskalySDKTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9BFF5C3244629610032D061 /* FiskalySDKTests.swift */; };
 		D9BFF5C6244629610032D061 /* FiskalySDK.h in Headers */ = {isa = PBXBuildFile; fileRef = D9BFF5B8244629610032D061 /* FiskalySDK.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D9F90FEF24478702002057D3 /* FiskalyHttpClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9F90FEE24478702002057D3 /* FiskalyHttpClient.swift */; };
-		E9760F3B26C17667004BB5D8 /* com.fiskaly.client-ios-all-v2.0.0.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = E9760F3A26C17667004BB5D8 /* com.fiskaly.client-ios-all-v2.0.0.xcframework */; };
+		E94CE9AD26C2D84800451C4E /* com.fiskaly.client-ios-all-v2.0.0 in Frameworks */ = {isa = PBXBuildFile; productRef = E94CE9AC26C2D84800451C4E /* com.fiskaly.client-ios-all-v2.0.0 */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -66,8 +66,8 @@
 		D9BFF5C5244629610032D061 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		D9F90FEE24478702002057D3 /* FiskalyHttpClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FiskalyHttpClient.swift; sourceTree = "<group>"; };
 		D9F90FF424478A8C002057D3 /* readme.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = readme.md; sourceTree = "<group>"; };
+		E94CE9A926C2B00400451C4E /* FiskalyClient */ = {isa = PBXFileReference; lastKnownFileType = folder; path = FiskalyClient; sourceTree = "<group>"; };
 		E951483C268233DC0026A559 /* build_xcframework.sh */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.sh; path = build_xcframework.sh; sourceTree = "<group>"; };
-		E9760F3A26C17667004BB5D8 /* com.fiskaly.client-ios-all-v2.0.0.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; path = "com.fiskaly.client-ios-all-v2.0.0.xcframework"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -75,7 +75,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				E9760F3B26C17667004BB5D8 /* com.fiskaly.client-ios-all-v2.0.0.xcframework in Frameworks */,
+				E94CE9AD26C2D84800451C4E /* com.fiskaly.client-ios-all-v2.0.0 in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -123,6 +123,7 @@
 		D9BFF5AB244629610032D061 = {
 			isa = PBXGroup;
 			children = (
+				E94CE9A926C2B00400451C4E /* FiskalyClient */,
 				D9F90FF424478A8C002057D3 /* readme.md */,
 				E951483C268233DC0026A559 /* build_xcframework.sh */,
 				D9BFF5B7244629610032D061 /* FiskalySDK */,
@@ -167,7 +168,6 @@
 		D9BFF5D624464D1B0032D061 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				E9760F3A26C17667004BB5D8 /* com.fiskaly.client-ios-all-v2.0.0.xcframework */,
 			);
 			path = Frameworks;
 			sourceTree = "<group>";
@@ -191,7 +191,6 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = D9BFF5C9244629610032D061 /* Build configuration list for PBXNativeTarget "FiskalySDK" */;
 			buildPhases = (
-				6AEFEB422487A03E00021EAC /* Fetch Client Library */,
 				D9BFF5B0244629610032D061 /* Headers */,
 				D9BFF5B1244629610032D061 /* Sources */,
 				D9BFF5B2244629610032D061 /* Frameworks */,
@@ -202,6 +201,9 @@
 			dependencies = (
 			);
 			name = FiskalySDK;
+			packageProductDependencies = (
+				E94CE9AC26C2D84800451C4E /* com.fiskaly.client-ios-all-v2.0.0 */,
+			);
 			productName = FiskalySDK;
 			productReference = D9BFF5B5244629610032D061 /* FiskalySDK.framework */;
 			productType = "com.apple.product-type.framework";
@@ -284,24 +286,6 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		6AEFEB422487A03E00021EAC /* Fetch Client Library */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-			);
-			name = "Fetch Client Library";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "CLIENT=com.fiskaly.client-ios-all-v2.0.0\n\ncd Frameworks\n\nif [ ! -f $CLIENT.xcframework ];\nthen \ncurl -s -o $CLIENT.zip https://storage.googleapis.com/fiskaly-cdn/clients/$CLIENT.zip\n    unzip $CLIENT.zip \n    rm $CLIENT.zip \nfi\n";
-		};
 		E9A6831226833E86000605EF /* Make XCFramework */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -684,6 +668,13 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		E94CE9AC26C2D84800451C4E /* com.fiskaly.client-ios-all-v2.0.0 */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = "com.fiskaly.client-ios-all-v2.0.0";
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = D9BFF5AC244629610032D061 /* Project object */;
 }

--- a/FiskalySDK.xcodeproj/project.pbxproj
+++ b/FiskalySDK.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 50;
+	objectVersion = 52;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -20,8 +20,8 @@
 		D9BFF5C4244629610032D061 /* FiskalySDKTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9BFF5C3244629610032D061 /* FiskalySDKTests.swift */; };
 		D9BFF5C6244629610032D061 /* FiskalySDK.h in Headers */ = {isa = PBXBuildFile; fileRef = D9BFF5B8244629610032D061 /* FiskalySDK.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D9F90FEF24478702002057D3 /* FiskalyHttpClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9F90FEE24478702002057D3 /* FiskalyHttpClient.swift */; };
-		E9807174266FAB5A00A099C2 /* com.fiskaly.client-ios-all-v1.2.200.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E980716E266A1C8400A099C2 /* com.fiskaly.client-ios-all-v1.2.200.a */; };
-		E9807175266FAB5B00A099C2 /* com.fiskaly.client-ios-all-v1.2.200.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E980716E266A1C8400A099C2 /* com.fiskaly.client-ios-all-v1.2.200.a */; };
+		E99EA8502678968A00B04017 /* com.fiskaly.client-ios-all-v1.2.200.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = E99EA84F2678968A00B04017 /* com.fiskaly.client-ios-all-v1.2.200.xcframework */; };
+		E99EA8512678968A00B04017 /* com.fiskaly.client-ios-all-v1.2.200.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = E99EA84F2678968A00B04017 /* com.fiskaly.client-ios-all-v1.2.200.xcframework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -55,6 +55,7 @@
 		D9F90FF424478A8C002057D3 /* readme.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = readme.md; sourceTree = "<group>"; };
 		E980716E266A1C8400A099C2 /* com.fiskaly.client-ios-all-v1.2.200.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = "com.fiskaly.client-ios-all-v1.2.200.a"; sourceTree = "<group>"; };
 		E9807171266FA5FE00A099C2 /* com.fiskaly.client-darwin-arm64-v1.2.100.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; path = "com.fiskaly.client-darwin-arm64-v1.2.100.dylib"; sourceTree = "<group>"; };
+		E99EA84F2678968A00B04017 /* com.fiskaly.client-ios-all-v1.2.200.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; path = "com.fiskaly.client-ios-all-v1.2.200.xcframework"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -62,7 +63,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				E9807174266FAB5A00A099C2 /* com.fiskaly.client-ios-all-v1.2.200.a in Frameworks */,
+				E99EA8502678968A00B04017 /* com.fiskaly.client-ios-all-v1.2.200.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -71,7 +72,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				D9BFF5BF244629610032D061 /* FiskalySDK.framework in Frameworks */,
-				E9807175266FAB5B00A099C2 /* com.fiskaly.client-ios-all-v1.2.200.a in Frameworks */,
+				E99EA8512678968A00B04017 /* com.fiskaly.client-ios-all-v1.2.200.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -154,6 +155,7 @@
 		D9BFF5D624464D1B0032D061 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				E99EA84F2678968A00B04017 /* com.fiskaly.client-ios-all-v1.2.200.xcframework */,
 				E9807171266FA5FE00A099C2 /* com.fiskaly.client-darwin-arm64-v1.2.100.dylib */,
 				E980716E266A1C8400A099C2 /* com.fiskaly.client-ios-all-v1.2.200.a */,
 			);

--- a/FiskalySDK.xcodeproj/project.pbxproj
+++ b/FiskalySDK.xcodeproj/project.pbxproj
@@ -34,8 +34,7 @@
 		D9BFF5C4244629610032D061 /* FiskalySDKTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9BFF5C3244629610032D061 /* FiskalySDKTests.swift */; };
 		D9BFF5C6244629610032D061 /* FiskalySDK.h in Headers */ = {isa = PBXBuildFile; fileRef = D9BFF5B8244629610032D061 /* FiskalySDK.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D9F90FEF24478702002057D3 /* FiskalyHttpClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9F90FEE24478702002057D3 /* FiskalyHttpClient.swift */; };
-		E99EA8502678968A00B04017 /* com.fiskaly.client-ios-all-v1.2.200.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = E99EA84F2678968A00B04017 /* com.fiskaly.client-ios-all-v1.2.200.xcframework */; };
-		E99EA8512678968A00B04017 /* com.fiskaly.client-ios-all-v1.2.200.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = E99EA84F2678968A00B04017 /* com.fiskaly.client-ios-all-v1.2.200.xcframework */; };
+		E9760F3B26C17667004BB5D8 /* com.fiskaly.client-ios-all-v2.0.0.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = E9760F3A26C17667004BB5D8 /* com.fiskaly.client-ios-all-v2.0.0.xcframework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -68,7 +67,7 @@
 		D9F90FEE24478702002057D3 /* FiskalyHttpClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FiskalyHttpClient.swift; sourceTree = "<group>"; };
 		D9F90FF424478A8C002057D3 /* readme.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = readme.md; sourceTree = "<group>"; };
 		E951483C268233DC0026A559 /* build_xcframework.sh */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.sh; path = build_xcframework.sh; sourceTree = "<group>"; };
-		E99EA84F2678968A00B04017 /* com.fiskaly.client-ios-all-v1.2.200.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; path = "com.fiskaly.client-ios-all-v1.2.200.xcframework"; sourceTree = "<group>"; };
+		E9760F3A26C17667004BB5D8 /* com.fiskaly.client-ios-all-v2.0.0.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; path = "com.fiskaly.client-ios-all-v2.0.0.xcframework"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -76,7 +75,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				E99EA8502678968A00B04017 /* com.fiskaly.client-ios-all-v1.2.200.xcframework in Frameworks */,
+				E9760F3B26C17667004BB5D8 /* com.fiskaly.client-ios-all-v2.0.0.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -85,7 +84,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				D9BFF5BF244629610032D061 /* FiskalySDK.framework in Frameworks */,
-				E99EA8512678968A00B04017 /* com.fiskaly.client-ios-all-v1.2.200.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -169,7 +167,7 @@
 		D9BFF5D624464D1B0032D061 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				E99EA84F2678968A00B04017 /* com.fiskaly.client-ios-all-v1.2.200.xcframework */,
+				E9760F3A26C17667004BB5D8 /* com.fiskaly.client-ios-all-v2.0.0.xcframework */,
 			);
 			path = Frameworks;
 			sourceTree = "<group>";
@@ -302,7 +300,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "CLIENT=com.fiskaly.client-ios-all-v1.2.100.a\n\nif [ ! -f $CLIENT ];\nthen \ncurl -s -o $CLIENT https://storage.googleapis.com/fiskaly-cdn/clients/$CLIENT\nfi\n";
+			shellScript = "CLIENT=com.fiskaly.client-ios-all-v2.0.0\n\ncd Frameworks\n\nif [ ! -f $CLIENT.xcframework ];\nthen \ncurl -s -o $CLIENT.zip https://storage.googleapis.com/fiskaly-cdn/clients/$CLIENT.zip\n    unzip $CLIENT.zip \n    rm $CLIENT.zip \nfi\n";
 		};
 		E9A6831226833E86000605EF /* Make XCFramework */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/FiskalySDK.xcodeproj/project.pbxproj
+++ b/FiskalySDK.xcodeproj/project.pbxproj
@@ -326,10 +326,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = (
-					arm64,
-					x86_64,
-				);
 				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
@@ -383,13 +379,11 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
-				ONLY_ACTIVE_ARCH = YES;
 				OTHER_LDFLAGS = "";
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				VALID_ARCHS = arm64;
-				"VALID_ARCHS[sdk=iphonesimulator*]" = "arm64 x86_64";
+				VALID_ARCHS = "$(ARCHS_STANDARD)";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -399,10 +393,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = (
-					arm64,
-					x86_64,
-				);
 				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
@@ -450,14 +440,12 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
-				ONLY_ACTIVE_ARCH = YES;
 				OTHER_LDFLAGS = "";
 				SDKROOT = iphoneos;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
 				VALIDATE_PRODUCT = YES;
-				VALID_ARCHS = arm64;
-				"VALID_ARCHS[sdk=iphonesimulator*]" = "arm64 x86_64";
+				VALID_ARCHS = "$(ARCHS_STANDARD)";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -501,9 +489,7 @@
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				VALIDATE_WORKSPACE = YES;
-				VALID_ARCHS = arm64;
-				"VALID_ARCHS[sdk=iphonesimulator*]" = "arm64 x86_64";
+				VALID_ARCHS = "$(ARCHS_STANDARD)";
 				VERSIONING_SYSTEM = "apple-generic";
 			};
 			name = Debug;
@@ -545,9 +531,7 @@
 				SUPPORTS_MACCATALYST = NO;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				VALIDATE_WORKSPACE = YES;
-				VALID_ARCHS = arm64;
-				"VALID_ARCHS[sdk=iphonesimulator*]" = "arm64 x86_64";
+				VALID_ARCHS = "$(ARCHS_STANDARD)";
 				VERSIONING_SYSTEM = "apple-generic";
 			};
 			name = Release;
@@ -556,7 +540,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)",
@@ -577,8 +560,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				VALID_ARCHS = arm64;
-				"VALID_ARCHS[sdk=iphonesimulator*]" = "arm64 x86_64";
+				VALID_ARCHS = "$(ARCHS_STANDARD)";
 			};
 			name = Debug;
 		};
@@ -586,7 +568,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)",
@@ -607,8 +588,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				VALID_ARCHS = arm64;
-				"VALID_ARCHS[sdk=iphonesimulator*]" = "arm64 x86_64";
+				VALID_ARCHS = "$(ARCHS_STANDARD)";
 			};
 			name = Release;
 		};

--- a/FiskalySDK.xcodeproj/project.pbxproj
+++ b/FiskalySDK.xcodeproj/project.pbxproj
@@ -53,8 +53,6 @@
 		D9BFF5C5244629610032D061 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		D9F90FEE24478702002057D3 /* FiskalyHttpClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FiskalyHttpClient.swift; sourceTree = "<group>"; };
 		D9F90FF424478A8C002057D3 /* readme.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = readme.md; sourceTree = "<group>"; };
-		E980716E266A1C8400A099C2 /* com.fiskaly.client-ios-all-v1.2.200.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = "com.fiskaly.client-ios-all-v1.2.200.a"; sourceTree = "<group>"; };
-		E9807171266FA5FE00A099C2 /* com.fiskaly.client-darwin-arm64-v1.2.100.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; path = "com.fiskaly.client-darwin-arm64-v1.2.100.dylib"; sourceTree = "<group>"; };
 		E99EA84F2678968A00B04017 /* com.fiskaly.client-ios-all-v1.2.200.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; path = "com.fiskaly.client-ios-all-v1.2.200.xcframework"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -156,8 +154,6 @@
 			isa = PBXGroup;
 			children = (
 				E99EA84F2678968A00B04017 /* com.fiskaly.client-ios-all-v1.2.200.xcframework */,
-				E9807171266FA5FE00A099C2 /* com.fiskaly.client-darwin-arm64-v1.2.100.dylib */,
-				E980716E266A1C8400A099C2 /* com.fiskaly.client-ios-all-v1.2.200.a */,
 			);
 			path = Frameworks;
 			sourceTree = "<group>";

--- a/FiskalySDK.xcodeproj/xcshareddata/xcschemes/FiskalySDK.xcscheme
+++ b/FiskalySDK.xcodeproj/xcshareddata/xcschemes/FiskalySDK.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1150"
+   LastUpgradeVersion = "1250"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/FiskalySDK/Classes/FiskalyHttpClient.swift
+++ b/FiskalySDK/Classes/FiskalyHttpClient.swift
@@ -193,7 +193,7 @@ public class FiskalyHttpClient {
             decoder.keyDecodingStrategy = .convertFromSnakeCase
             response = try decoder.decode(JsonRpcResponse<T>.self, from: data)
         } catch {
-            throw FiskalyError.sdkError(message: "Client response not decodable into class. \(error), data = \(jsonData.data)")
+            throw FiskalyError.sdkError(message: "Client response not decodable into class. \(error), data = \(jsonData)")
         }
 
         print(response.error?.data?.response.body ?? "NO ERROR")

--- a/FiskalySDK/Classes/FiskalyHttpClient.swift
+++ b/FiskalySDK/Classes/FiskalyHttpClient.swift
@@ -183,7 +183,7 @@ public class FiskalyHttpClient {
 
         let jsonData = try client.invoke(request: request)
         guard let data = jsonData.data(using: .utf8) else {
-            throw FiskalyError.sdkError(message: "Client response not decodeable into JSON.")
+            throw FiskalyError.sdkError(message: "Client response not encodable into JSON.")
         }
 
         let response: JsonRpcResponse<T>
@@ -193,7 +193,7 @@ public class FiskalyHttpClient {
             decoder.keyDecodingStrategy = .convertFromSnakeCase
             response = try decoder.decode(JsonRpcResponse<T>.self, from: data)
         } catch {
-            throw FiskalyError.sdkError(message: "Client response not decodable into class.")
+            throw FiskalyError.sdkError(message: "Client response not decodable into class. \(error), data = \(jsonData.data)")
         }
 
         print(response.error?.data?.response.body ?? "NO ERROR")

--- a/FiskalySDK/Classes/JsonRpc/JsonRpcError.swift
+++ b/FiskalySDK/Classes/JsonRpc/JsonRpcError.swift
@@ -16,6 +16,6 @@ public class JsonRpcError: Error, Codable {
 extension JsonRpcError: CustomDebugStringConvertible {
 
     public var debugDescription: String {
-        return "JSON RPC error \(code): \(message)\n\(data?.context ?? "no context")"
+        return "JSON RPC error \(code): \(message)\n\(data?.response.body ?? "no response body")"
     }
 }

--- a/FiskalySDK/Classes/JsonRpc/JsonRpcError.swift
+++ b/FiskalySDK/Classes/JsonRpc/JsonRpcError.swift
@@ -5,30 +5,12 @@ public class JsonRpcError: Error, Codable {
     public var code: Int
     public var message: String
     public var data: ResultRequest?
-
+    
     private enum CodingKeys: String, CodingKey {
         case code
         case message
         case data
     }
-
-    public required init(from decoder: Decoder) throws {
-        do {
-            let container   = try decoder.container(keyedBy: CodingKeys.self)
-
-            self.code       = try container.decode(Int.self, forKey: .code)
-            self.message    = try container.decode(String.self, forKey: .message)
-
-            if let data     = try container.decodeIfPresent(ResultRequest.self, forKey: .data) {
-                self.data = data
-            }
-        } catch {
-            message = "Could not create error: \(error.localizedDescription)"
-            throw error
-        }
-
-    }
-
 }
 
 extension JsonRpcError: CustomDebugStringConvertible {

--- a/FiskalySDK/Classes/JsonRpc/JsonRpcError.swift
+++ b/FiskalySDK/Classes/JsonRpc/JsonRpcError.swift
@@ -13,16 +13,27 @@ public class JsonRpcError: Error, Codable {
     }
 
     public required init(from decoder: Decoder) throws {
+        do {
+            let container   = try decoder.container(keyedBy: CodingKeys.self)
 
-        let container   = try decoder.container(keyedBy: CodingKeys.self)
+            self.code       = try container.decode(Int.self, forKey: .code)
+            self.message    = try container.decode(String.self, forKey: .message)
 
-        self.code       = try container.decode(Int.self, forKey: .code)
-        self.message    = try container.decode(String.self, forKey: .message)
-
-        if let data     = try container.decodeIfPresent(ResultRequest.self, forKey: .data) {
-            self.data = data
+            if let data     = try container.decodeIfPresent(ResultRequest.self, forKey: .data) {
+                self.data = data
+            }
+        } catch {
+            message = "Could not create error: \(error.localizedDescription)"
+            throw error
         }
 
     }
 
+}
+
+extension JsonRpcError: CustomDebugStringConvertible {
+
+    public var debugDescription: String {
+        return "JSON RPC error \(code): \(message)\n\(data?.context ?? "no context")"
+    }
 }

--- a/FiskalySDK/Classes/JsonRpc/JsonRpcResponse.swift
+++ b/FiskalySDK/Classes/JsonRpc/JsonRpcResponse.swift
@@ -13,21 +13,4 @@ public class JsonRpcResponse<T: Codable>: Codable {
         case result
         case error
     }
-
-    public required init(from decoder: Decoder) throws {
-
-        let container   = try decoder.container(keyedBy: CodingKeys.self)
-
-        self.jsonrpc    = try container.decode(String.self, forKey: .jsonrpc)
-        self.id         = try container.decode(String.self, forKey: .id)
-
-        if let result   = try container.decodeIfPresent(T.self, forKey: .result) {
-            self.result = result
-        }
-        if let error    = try container.decodeIfPresent(JsonRpcError.self, forKey: .error) {
-            self.error = error
-        }
-
-    }
-
 }

--- a/FiskalySDK/Classes/Results.swift
+++ b/FiskalySDK/Classes/Results.swift
@@ -33,7 +33,7 @@ public class SMAERSVersion: Codable {
 
 public class ResultSelfTest: Codable {
     public var proxy: String
-    public var backend: String
+    public var backend: [String:String]
     public var smaers: String
 }
 

--- a/FiskalySDKTests/FiskalyAPITests.swift
+++ b/FiskalySDKTests/FiskalyAPITests.swift
@@ -16,7 +16,6 @@ class FiskalyAPITests: XCTestCase {
     }
 
     func testManagementRequest() throws {
-        do {
         let client = try FiskalyHttpClient(
             apiKey: "",
             apiSecret: "",
@@ -28,10 +27,6 @@ class FiskalyAPITests: XCTestCase {
             method: "GET",
             path: "/organizations")
             XCTAssertEqual(response.status, 200)
-        } catch let error {
-            print("Unexpected error: \(error).")
-            throw error
-        }
     }
 
     func testTransactionRequest() throws {

--- a/FiskalySDKTests/FiskalyAPITests.swift
+++ b/FiskalySDKTests/FiskalyAPITests.swift
@@ -16,6 +16,7 @@ class FiskalyAPITests: XCTestCase {
     }
 
     func testManagementRequest() throws {
+        do {
         let client = try FiskalyHttpClient(
             apiKey: "",
             apiSecret: "",
@@ -26,7 +27,11 @@ class FiskalyAPITests: XCTestCase {
         let response = try client.request(
             method: "GET",
             path: "/organizations")
-        XCTAssertEqual(response.status, 200)
+            XCTAssertEqual(response.status, 200)
+        } catch let error {
+            print("Unexpected error: \(error).")
+            throw error
+        }
     }
 
     func testTransactionRequest() throws {

--- a/FiskalySDKTests/FiskalyClientTests.swift
+++ b/FiskalySDKTests/FiskalyClientTests.swift
@@ -23,7 +23,7 @@ class FiskalyClientTests: XCTestCase {
             baseUrl: "https://kassensichv.io/api/v1/"
         )
         let response = try client.selfTest()
-        XCTAssertNotEqual(response.backend, "")
+        XCTAssertNotEqual(response.backend, [:])
         XCTAssertNotEqual(response.smaers, "")
     }
 

--- a/FiskalySDKTests/FiskalyClientTests.swift
+++ b/FiskalySDKTests/FiskalyClientTests.swift
@@ -23,7 +23,7 @@ class FiskalyClientTests: XCTestCase {
             baseUrl: "https://kassensichv.io/api/v1/"
         )
         let response = try client.selfTest()
-        XCTAssertNotEqual(response.backend, [:])
+        XCTAssertFalse(response.backend.isEmpty)
         XCTAssertNotEqual(response.smaers, "")
     }
 

--- a/build_xcframework.sh
+++ b/build_xcframework.sh
@@ -1,0 +1,92 @@
+env > env.txt
+instruments -s devices > devices.txt
+#! /bin/sh -e
+# This script demonstrates archive and create action on frameworks and libraries
+# Based on script by @author Boris Bielik
+
+# Release dir path
+OUTPUT_DIR_PATH="${PROJECT_DIR}/XCFramework"
+
+function archivePathSimulator {
+  local DIR=${OUTPUT_DIR_PATH}/archives/"${1}-SIMULATOR"
+  echo "${DIR}"
+}
+
+function archivePathDevice {
+  local DIR=${OUTPUT_DIR_PATH}/archives/"${1}-DEVICE"
+  echo "${DIR}"
+}
+
+# Archive takes 3 params
+#
+# 1st == SCHEME
+# 2nd == destination
+# 3rd == archivePath
+function archive {
+    echo "▸ Starts archiving the scheme: ${1} for destination: ${2};\n▸ Archive path: ${3}.xcarchive"
+    xcodebuild clean archive \
+    -project "${PROJECT_NAME}.xcodeproj" \
+    -scheme ${1} \
+    -configuration ${CONFIGURATION} \
+    -destination "${2}" \
+    -archivePath "${3}" \
+    SKIP_INSTALL=NO \
+    OBJROOT="${OBJROOT}/DependentBuilds" \
+    BUILD_LIBRARY_FOR_DISTRIBUTION=YES | xcpretty
+}
+
+# Builds archive for iOS simulator & device
+function buildArchive {
+  SCHEME=${1}
+
+  archive $SCHEME "generic/platform=iOS Simulator" $(archivePathSimulator $SCHEME)
+  archive $SCHEME "generic/platform=iOS" $(archivePathDevice $SCHEME)
+}
+
+# Creates xc framework
+function createXCFramework {
+  FRAMEWORK_ARCHIVE_PATH_POSTFIX=".xcarchive/Products/Library/Frameworks"
+  FRAMEWORK_SIMULATOR_DIR="$(archivePathSimulator $1)${FRAMEWORK_ARCHIVE_PATH_POSTFIX}"
+  FRAMEWORK_DEVICE_DIR="$(archivePathDevice $1)${FRAMEWORK_ARCHIVE_PATH_POSTFIX}"
+
+  xcodebuild -create-xcframework \
+            -framework ${FRAMEWORK_SIMULATOR_DIR}/${1}.framework \
+            -framework ${FRAMEWORK_DEVICE_DIR}/${1}.framework \
+            -output ${OUTPUT_DIR_PATH}/xcframeworks/${1}.xcframework
+}
+
+### Static Libraries cant be turned into frameworks
+function createXCFrameworkForStaticLibrary {
+
+  LIBRARY_ARCHIVE_PATH_POSTFIX=".xcarchive/Products/usr/local/lib"
+  LIBRARY_SIMULATOR_DIR="$(archivePathSimulator $1)${LIBRARY_ARCHIVE_PATH_POSTFIX}"
+  LIBRARY_DEVICE_DIR="$(archivePathDevice $1)${LIBRARY_ARCHIVE_PATH_POSTFIX}"
+
+  xcodebuild -create-xcframework \
+            -library ${LIBRARY_SIMULATOR_DIR}/libStaticLibrary.a \
+            -library ${LIBRARY_DEVICE_DIR}/libStaticLibrary.a \
+            -output ${OUTPUT_DIR_PATH}/xcframeworks/${1}.xcframework
+}
+
+echo "#####################"
+echo "▸ Cleaning the dir: ${OUTPUT_DIR_PATH}"
+rm -rf $OUTPUT_DIR_PATH
+
+#### Static Library ####
+#LIBRARY="${PROJECT_NAME}"
+
+#echo "▸ Archive $LIBRARY"
+#buildArchive ${LIBRARY}
+
+#echo "▸ Create $FRAMEWORK.xcframework"
+#createXCFrameworkForStaticLibrary ${LIBRARY}
+
+#### Dynamic Framework ####
+
+DYNAMIC_FRAMEWORK="${PROJECT_NAME}"
+
+echo "▸ Archive $DYNAMIC_FRAMEWORK"
+buildArchive ${DYNAMIC_FRAMEWORK}
+
+echo "▸ Create $DYNAMIC_FRAMEWORK.xcframework"
+createXCFramework ${DYNAMIC_FRAMEWORK}


### PR DESCRIPTION
**This relies on the client xcframework generated by https://github.com/fiskaly/client/pull/210**
[com.fiskaly.client-ios-all-v1.2.200.xcframework.zip](https://github.com/fiskaly/fiskaly-sdk-swift/files/6670652/com.fiskaly.client-ios-all-v1.2.200.xcframework.zip)


## Motivation

To get the tests to run (and pass, when appropriate environment variables are set) in the simulator on an M1 Mac, to fix #36 and the broken testSelfTest test.

## Test Plan

Set API_SECRET, API_KEY, PASSWORD, and EMAIL environment variables, and ran the existing tests on M1 and Intel-based Macs. Also built SDK for a device to ensure that still works.
